### PR TITLE
fix: bump tambo react to avoid error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "tambo-template",
       "version": "0.1.0",
       "dependencies": {
-        "@tambo-ai/react": "^0.19.6",
+        "@tambo-ai/react": "^0.19.8",
         "class-variance-authority": "^0.7.1",
         "lucide-react": "^0.484.0",
         "next": "15.2.3",
@@ -2495,9 +2495,9 @@
       }
     },
     "node_modules/@tambo-ai/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@tambo-ai/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-iyCfYfI1PdVDTL/TQPzsI/J9+DD8TMnDJx4/OMu5Jw7EaYXMe70KCSgHWRhvj8RS9u9cUbm1DiqBzvDXVq2OSg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/react/-/react-0.19.8.tgz",
+      "integrity": "sha512-9DdGtr+zF0sttLofGKPrvjvPA9Fe0BhBmLJwxAEAr8AmY69h4kIhnEpfWhOiph/JRXPbrKAkP14Y9N+YTjkHjQ==",
       "dependencies": {
         "@tambo-ai/typescript-sdk": "^0.42.0",
         "@tanstack/react-query": "^5.71.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@tambo-ai/react": "^0.19.6",
+    "@tambo-ai/react": "^0.19.8",
     "class-variance-authority": "^0.7.1",
     "lucide-react": "^0.484.0",
     "next": "15.2.3",


### PR DESCRIPTION
Latest react package shows 'tamboprovider must be used in browser' as a console error instead of a thrown error